### PR TITLE
issue-4: Fix openorders to make market optional

### DIFF
--- a/src/bittrex-client.js
+++ b/src/bittrex-client.js
@@ -158,7 +158,6 @@ class BittrexClient {
    * @return {Promise}
    */
   async openOrders(market) {
-    if (!market) throw new Error('market is required')
     let params = { market }
     let results = await this.request('get', '/market/getopenorders', { params })
     return this.parseDates(results, ['Opened'])


### PR DESCRIPTION
Fixed `openOrders` by remove error rising. `/market/getopenorders` endpoint of API v1.1 has optional market parameter to fetch all open orders in one request